### PR TITLE
Mandal-Art-1 보드 셀 드래그앤 드롭 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "gh-pages": "^3.1.0",
     "node-sass": "^4.14.1",
     "react": "^17.0.1",
+    "react-dnd": "^11.1.3",
+    "react-dnd-html5-backend": "^11.1.3",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.2.0",

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -44,7 +44,7 @@ const Board = ({ board, setBoards, boardIndex }) => {
         boardIndex={boardIndex}
         onMoveItem={moveItem}
         onDropItem={dropItem}
-        canDrag={canDrag}
+        canDrag={boardIndex !== BOARD_CENTER_INDEX && canDrag}
       >
         <GridItem>
           <BoardCell

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -1,23 +1,49 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 
+import DragItem from 'components/DragItem/DragItem';
+import { GridContext } from 'context/GridContext';
 import BoardCell from './BoardCell/BoardCell';
 import { BOARD_LENGTH } from 'constants/board';
+import { replaceArrayOnArray } from 'utils/utils';
 
-import { GridContainer } from './Board.styles';
+import { GridContainer, GridItemWrapper } from './Board.styles';
+
+const GridItem = ({ forwardedRef, ...props }) => (
+  <GridItemWrapper ref={forwardedRef} {...props} />
+);
 
 const Board = ({ board, setBoards, boardIndex }) => {
-  // console.log(board);
+  const {
+    state: { dragItems },
+    actions: { moveItem, setDragItems },
+  } = useContext(GridContext);
+
+  useEffect(() => {
+    setDragItems((prevState) =>
+      replaceArrayOnArray(prevState, boardIndex, board)
+    );
+  }, [setDragItems, board, boardIndex]);
+  // console.log(dragItems[boardIndex]);
+
   return (
     <GridContainer>
-      {board.slice(0, BOARD_LENGTH).map((cell, index) => (
-        <BoardCell
+      {dragItems[boardIndex]?.slice(0, BOARD_LENGTH).map((cell, index) => (
+        <DragItem
           key={cell.id}
-          cell={cell}
-          setBoards={setBoards}
-          board={board}
+          id={cell.id}
           boardIndex={boardIndex}
-          cellIndex={index}
-        />
+          onMoveItem={moveItem}
+        >
+          <GridItem>
+            <BoardCell
+              key={cell.id}
+              cell={cell}
+              setBoards={setBoards}
+              boardIndex={boardIndex}
+              cellIndex={index}
+            />
+          </GridItem>
+        </DragItem>
       ))}
     </GridContainer>
   );

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useContext } from 'react';
+import { Spinner } from 'remember-ui';
 
 import DragItem from 'components/DragItem/DragItem';
 import { GridContext } from 'context/GridContext';
+import { TrelloContext } from 'context/TrelloContext';
 import BoardCell from './BoardCell/BoardCell';
 import { BOARD_CENTER_INDEX } from 'constants/board';
 import { replaceArrayOnArray } from 'utils/utils';
 
-import { GridContainer, GridItemWrapper } from './Board.styles';
+import { GridContainer, GridItemWrapper, GridOverlay } from './Board.styles';
 
 const GridItem = ({ forwardedRef, ...props }) => (
   <GridItemWrapper ref={forwardedRef} {...props} />
@@ -17,9 +19,13 @@ const Board = ({ board, setBoards, boardIndex }) => {
     state: { dragItems },
     actions: { moveItem, dropItem, setDragItems },
   } = useContext(GridContext);
+
+  const {
+    state: { canDrag },
+  } = useContext(TrelloContext);
+
   const centerCell = board.filter((el) => el.isCenter);
-  // const newBoard = board.filter((el) => !el.isCenter);
-  // console.log(board);
+
   useEffect(() => {
     setDragItems((prevState) =>
       replaceArrayOnArray(
@@ -29,7 +35,6 @@ const Board = ({ board, setBoards, boardIndex }) => {
       )
     );
   }, [boardIndex, board, setDragItems]);
-  // console.log(dragItems[boardIndex]);
 
   const renderDragItem = (item, index) => {
     return (
@@ -39,6 +44,7 @@ const Board = ({ board, setBoards, boardIndex }) => {
         boardIndex={boardIndex}
         onMoveItem={moveItem}
         onDropItem={dropItem}
+        canDrag={canDrag}
       >
         <GridItem>
           <BoardCell
@@ -56,6 +62,11 @@ const Board = ({ board, setBoards, boardIndex }) => {
     <>
       {dragItems && dragItems[boardIndex] && dragItems[boardIndex].length > 0 && (
         <GridContainer>
+          {!canDrag && (
+            <GridOverlay>
+              <Spinner />
+            </GridOverlay>
+          )}
           {renderDragItem(dragItems[boardIndex][0], 0)}
           {renderDragItem(dragItems[boardIndex][1], 1)}
           {renderDragItem(dragItems[boardIndex][2], 2)}

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -32,57 +32,157 @@ const Board = ({ board, setBoards, boardIndex }) => {
   // console.log(dragItems[boardIndex]);
 
   return (
-    <GridContainer>
-      {dragItems[boardIndex]
-        ?.slice(0, BOARD_CENTER_INDEX)
-        .map((cell, index) => (
+    <>
+      {dragItems && dragItems[boardIndex] && dragItems[boardIndex].length > 0 && (
+        <GridContainer>
           <DragItem
-            key={cell.id}
-            id={cell.id}
+            key={dragItems[boardIndex][0]?.id}
+            id={dragItems[boardIndex][0]?.id}
             boardIndex={boardIndex}
             onMoveItem={moveItem}
           >
             <GridItem>
               <BoardCell
-                key={cell.id}
-                cell={cell}
+                key={dragItems[boardIndex][0]?.id}
+                cell={dragItems[boardIndex][0]}
                 setBoards={setBoards}
                 boardIndex={boardIndex}
-                cellIndex={index}
+                cellIndex={0}
               />
             </GridItem>
           </DragItem>
-        ))}
-      <GridItem>
-        <BoardCell
-          key={centerCell[0].id}
-          cell={centerCell[0]}
-          setBoards={setBoards}
-          boardIndex={boardIndex}
-          cellIndex={BOARD_CENTER_INDEX}
-        />
-      </GridItem>
-      {dragItems[boardIndex]
-        ?.slice(BOARD_CENTER_INDEX, BOARD_LENGTH - 1)
-        .map((cell, index) => (
+
           <DragItem
-            key={cell.id}
-            id={cell.id}
+            key={dragItems[boardIndex][1]?.id}
+            id={dragItems[boardIndex][1]?.id}
             boardIndex={boardIndex}
             onMoveItem={moveItem}
           >
             <GridItem>
               <BoardCell
-                key={cell.id}
-                cell={cell}
+                key={dragItems[boardIndex][1]?.id}
+                cell={dragItems[boardIndex][1]}
                 setBoards={setBoards}
                 boardIndex={boardIndex}
-                cellIndex={index + BOARD_CENTER_INDEX + 1}
+                cellIndex={1}
               />
             </GridItem>
           </DragItem>
-        ))}
-    </GridContainer>
+
+          <DragItem
+            key={dragItems[boardIndex][2]?.id}
+            id={dragItems[boardIndex][2]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][2]?.id}
+                cell={dragItems[boardIndex][2]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={2}
+              />
+            </GridItem>
+          </DragItem>
+
+          <DragItem
+            key={dragItems[boardIndex][3]?.id}
+            id={dragItems[boardIndex][3]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][3]?.id}
+                cell={dragItems[boardIndex][3]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={3}
+              />
+            </GridItem>
+          </DragItem>
+
+          <GridItem>
+            <BoardCell
+              key={centerCell[0].id}
+              cell={centerCell[0]}
+              setBoards={setBoards}
+              boardIndex={boardIndex}
+              cellIndex={BOARD_CENTER_INDEX}
+            />
+          </GridItem>
+
+          <DragItem
+            key={dragItems[boardIndex][4]?.id}
+            id={dragItems[boardIndex][4]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][4]?.id}
+                cell={dragItems[boardIndex][4]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={4}
+              />
+            </GridItem>
+          </DragItem>
+
+          <DragItem
+            key={dragItems[boardIndex][5]?.id}
+            id={dragItems[boardIndex][5]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][5]?.id}
+                cell={dragItems[boardIndex][5]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={5}
+              />
+            </GridItem>
+          </DragItem>
+
+          <DragItem
+            key={dragItems[boardIndex][6]?.id}
+            id={dragItems[boardIndex][6]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][6]?.id}
+                cell={dragItems[boardIndex][6]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={6}
+              />
+            </GridItem>
+          </DragItem>
+
+          <DragItem
+            key={dragItems[boardIndex][7]?.id}
+            id={dragItems[boardIndex][7]?.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={dragItems[boardIndex][7]?.id}
+                cell={dragItems[boardIndex][7]}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={7}
+              />
+            </GridItem>
+          </DragItem>
+        </GridContainer>
+      )}
+    </>
   );
 };
 

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -3,7 +3,7 @@ import React, { useEffect, useContext } from 'react';
 import DragItem from 'components/DragItem/DragItem';
 import { GridContext } from 'context/GridContext';
 import BoardCell from './BoardCell/BoardCell';
-import { BOARD_LENGTH } from 'constants/board';
+import { BOARD_LENGTH, BOARD_CENTER_INDEX } from 'constants/board';
 import { replaceArrayOnArray } from 'utils/utils';
 
 import { GridContainer, GridItemWrapper } from './Board.styles';
@@ -17,34 +17,71 @@ const Board = ({ board, setBoards, boardIndex }) => {
     state: { dragItems },
     actions: { moveItem, setDragItems },
   } = useContext(GridContext);
-
+  const centerCell = board.filter((el) => el.isCenter);
+  // const newBoard = board.filter((el) => !el.isCenter);
+  // console.log(board);
   useEffect(() => {
     setDragItems((prevState) =>
-      replaceArrayOnArray(prevState, boardIndex, board)
+      replaceArrayOnArray(
+        prevState,
+        boardIndex,
+        board.filter((el) => !el.isCenter)
+      )
     );
-  }, [setDragItems, board, boardIndex]);
+  }, [boardIndex, board, setDragItems]);
   // console.log(dragItems[boardIndex]);
 
   return (
     <GridContainer>
-      {dragItems[boardIndex]?.slice(0, BOARD_LENGTH).map((cell, index) => (
-        <DragItem
-          key={cell.id}
-          id={cell.id}
+      {dragItems[boardIndex]
+        ?.slice(0, BOARD_CENTER_INDEX)
+        .map((cell, index) => (
+          <DragItem
+            key={cell.id}
+            id={cell.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={cell.id}
+                cell={cell}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={index}
+              />
+            </GridItem>
+          </DragItem>
+        ))}
+      <GridItem>
+        <BoardCell
+          key={centerCell[0].id}
+          cell={centerCell[0]}
+          setBoards={setBoards}
           boardIndex={boardIndex}
-          onMoveItem={moveItem}
-        >
-          <GridItem>
-            <BoardCell
-              key={cell.id}
-              cell={cell}
-              setBoards={setBoards}
-              boardIndex={boardIndex}
-              cellIndex={index}
-            />
-          </GridItem>
-        </DragItem>
-      ))}
+          cellIndex={BOARD_CENTER_INDEX}
+        />
+      </GridItem>
+      {dragItems[boardIndex]
+        ?.slice(BOARD_CENTER_INDEX, BOARD_LENGTH - 1)
+        .map((cell, index) => (
+          <DragItem
+            key={cell.id}
+            id={cell.id}
+            boardIndex={boardIndex}
+            onMoveItem={moveItem}
+          >
+            <GridItem>
+              <BoardCell
+                key={cell.id}
+                cell={cell}
+                setBoards={setBoards}
+                boardIndex={boardIndex}
+                cellIndex={index + BOARD_CENTER_INDEX + 1}
+              />
+            </GridItem>
+          </DragItem>
+        ))}
     </GridContainer>
   );
 };

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -3,7 +3,7 @@ import React, { useEffect, useContext } from 'react';
 import DragItem from 'components/DragItem/DragItem';
 import { GridContext } from 'context/GridContext';
 import BoardCell from './BoardCell/BoardCell';
-import { BOARD_LENGTH, BOARD_CENTER_INDEX } from 'constants/board';
+import { BOARD_CENTER_INDEX } from 'constants/board';
 import { replaceArrayOnArray } from 'utils/utils';
 
 import { GridContainer, GridItemWrapper } from './Board.styles';

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -15,7 +15,7 @@ const GridItem = ({ forwardedRef, ...props }) => (
 const Board = ({ board, setBoards, boardIndex }) => {
   const {
     state: { dragItems },
-    actions: { moveItem, setDragItems },
+    actions: { moveItem, dropItem, setDragItems },
   } = useContext(GridContext);
   const centerCell = board.filter((el) => el.isCenter);
   // const newBoard = board.filter((el) => !el.isCenter);
@@ -31,77 +31,35 @@ const Board = ({ board, setBoards, boardIndex }) => {
   }, [boardIndex, board, setDragItems]);
   // console.log(dragItems[boardIndex]);
 
+  const renderDragItem = (item, index) => {
+    return (
+      <DragItem
+        key={item?.id}
+        id={item?.id}
+        boardIndex={boardIndex}
+        onMoveItem={moveItem}
+        onDropItem={dropItem}
+      >
+        <GridItem>
+          <BoardCell
+            key={item?.id}
+            cell={item}
+            setBoards={setBoards}
+            boardIndex={boardIndex}
+            cellIndex={index}
+          />
+        </GridItem>
+      </DragItem>
+    );
+  };
   return (
     <>
       {dragItems && dragItems[boardIndex] && dragItems[boardIndex].length > 0 && (
         <GridContainer>
-          <DragItem
-            key={dragItems[boardIndex][0]?.id}
-            id={dragItems[boardIndex][0]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][0]?.id}
-                cell={dragItems[boardIndex][0]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={0}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][1]?.id}
-            id={dragItems[boardIndex][1]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][1]?.id}
-                cell={dragItems[boardIndex][1]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={1}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][2]?.id}
-            id={dragItems[boardIndex][2]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][2]?.id}
-                cell={dragItems[boardIndex][2]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={2}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][3]?.id}
-            id={dragItems[boardIndex][3]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][3]?.id}
-                cell={dragItems[boardIndex][3]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={3}
-              />
-            </GridItem>
-          </DragItem>
+          {renderDragItem(dragItems[boardIndex][0], 0)}
+          {renderDragItem(dragItems[boardIndex][1], 1)}
+          {renderDragItem(dragItems[boardIndex][2], 2)}
+          {renderDragItem(dragItems[boardIndex][3], 3)}
 
           <GridItem>
             <BoardCell
@@ -113,73 +71,10 @@ const Board = ({ board, setBoards, boardIndex }) => {
             />
           </GridItem>
 
-          <DragItem
-            key={dragItems[boardIndex][4]?.id}
-            id={dragItems[boardIndex][4]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][4]?.id}
-                cell={dragItems[boardIndex][4]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={4}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][5]?.id}
-            id={dragItems[boardIndex][5]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][5]?.id}
-                cell={dragItems[boardIndex][5]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={5}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][6]?.id}
-            id={dragItems[boardIndex][6]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][6]?.id}
-                cell={dragItems[boardIndex][6]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={6}
-              />
-            </GridItem>
-          </DragItem>
-
-          <DragItem
-            key={dragItems[boardIndex][7]?.id}
-            id={dragItems[boardIndex][7]?.id}
-            boardIndex={boardIndex}
-            onMoveItem={moveItem}
-          >
-            <GridItem>
-              <BoardCell
-                key={dragItems[boardIndex][7]?.id}
-                cell={dragItems[boardIndex][7]}
-                setBoards={setBoards}
-                boardIndex={boardIndex}
-                cellIndex={7}
-              />
-            </GridItem>
-          </DragItem>
+          {renderDragItem(dragItems[boardIndex][4], 4)}
+          {renderDragItem(dragItems[boardIndex][5], 5)}
+          {renderDragItem(dragItems[boardIndex][6], 6)}
+          {renderDragItem(dragItems[boardIndex][7], 7)}
         </GridContainer>
       )}
     </>

--- a/src/components/Board/Board.styles.js
+++ b/src/components/Board/Board.styles.js
@@ -18,6 +18,6 @@ export const GridOverlay = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: rgba(0, 0, 0, 0.05);
   z-index: 9700;
 `;

--- a/src/components/Board/Board.styles.js
+++ b/src/components/Board/Board.styles.js
@@ -1,10 +1,23 @@
 import styled from 'styled-components';
-import {} from 'remember-ui';
+import { flexContainer } from 'remember-ui';
 
 export const GridContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 8px;
+  position: relative;
 `;
 
 export const GridItemWrapper = styled.div``;
+
+export const GridOverlay = styled.div`
+  ${flexContainer('center', 'center')};
+
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 9700;
+`;

--- a/src/components/Board/Board.styles.js
+++ b/src/components/Board/Board.styles.js
@@ -6,3 +6,5 @@ export const GridContainer = styled.div`
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 8px;
 `;
+
+export const GridItemWrapper = styled.div``;

--- a/src/components/Board/BoardCell/BoardCell.js
+++ b/src/components/Board/BoardCell/BoardCell.js
@@ -140,20 +140,21 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
         name={cell.id}
         value={text}
         onKeyDown={onEnterPress}
-        disabled={cellIndex === BOARD_CENTER_INDEX}
+        disabled={cell.isCenter}
         onChange={(e) => {
           setText(e.target.value);
         }}
       />
 
-      {cellIndex === BOARD_CENTER_INDEX && (
+      {cell.isCenter && (
         <Hover>
           <HoverContainer>
             <HoverContainer.Plus />
           </HoverContainer>
         </Hover>
       )}
-      {cellIndex !== BOARD_CENTER_INDEX && cell.name && (
+
+      {!cell.isCenter && cell.name && (
         <HoverContainer.Close
           onClick={() => {
             openDeleteConfirmModal(

--- a/src/components/Board/BoardCell/BoardCell.js
+++ b/src/components/Board/BoardCell/BoardCell.js
@@ -34,7 +34,7 @@ const validateBeforeSave = (cell, board, text) => {
 };
 
 const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
-  // console.log(cell.name);
+  // console.log(cell);
   const {
     actions: { openDeleteConfirmModal },
   } = useContext(ConfirmModalContext);
@@ -48,9 +48,10 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
   useEffect(() => {
     setText(cell.name);
   }, [cell]);
-  const onEnter = useCallback(async () => {
-    const { id, trelloType, name, idList, idBoard } = cell;
 
+  const onEnter = useCallback(async () => {
+    const { id, trelloType, name, idList, idBoard, pos } = cell;
+    // console.log(cell);
     if (!validateBeforeSave(cell, boards[cellIndex], text)) {
       setText(name);
       return;
@@ -68,13 +69,13 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
       if (name) {
         updateList({ ...cell, name: text });
       } else {
-        responseOfNewCell = await createList(text, idBoard);
+        responseOfNewCell = await createList(text, idBoard, pos);
       }
     } else if (trelloType === TRELLO_COLLECTION_TYPE.CARDS) {
       if (name) {
         updateCard({ ...cell, name: text });
       } else {
-        responseOfNewCell = await createCard(text, idList);
+        responseOfNewCell = await createCard(text, idList, pos);
       }
     }
     // console.log(text);

--- a/src/components/Board/BoardCell/BoardCell.js
+++ b/src/components/Board/BoardCell/BoardCell.js
@@ -43,10 +43,10 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
     state: { boards },
   } = useContext(TrelloContext);
 
-  const [text, setText] = useState(cell.name);
+  const [text, setText] = useState(cell?.name);
 
   useEffect(() => {
-    setText(cell.name);
+    setText(cell?.name);
   }, [cell]);
 
   const onEnter = useCallback(async () => {
@@ -133,20 +133,20 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
 
   return (
     <Container
-      isCenter={cell.isCenter}
+      isCenter={cell?.isCenter}
       isMainBoard={boardIndex === BOARD_CENTER_INDEX}
     >
       <TextArea
-        name={cell.id}
+        name={cell?.id}
         value={text}
         onKeyDown={onEnterPress}
-        disabled={cell.isCenter}
+        disabled={cell?.isCenter}
         onChange={(e) => {
           setText(e.target.value);
         }}
       />
 
-      {cell.isCenter && (
+      {cell?.isCenter && (
         <Hover>
           <HoverContainer>
             <HoverContainer.Plus />
@@ -154,12 +154,12 @@ const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
         </Hover>
       )}
 
-      {!cell.isCenter && cell.name && (
+      {!cell?.isCenter && cell?.name && (
         <HoverContainer.Close
           onClick={() => {
             openDeleteConfirmModal(
               deleteOkCallback,
-              `"${cell.name}"을 삭제 하시겠습니까?`
+              `"${cell?.name}"을 삭제 하시겠습니까?`
             );
           }}
         />

--- a/src/components/Board/BoardCell/BoardCell.js
+++ b/src/components/Board/BoardCell/BoardCell.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext } from 'react';
+import React, { useEffect, useState, useCallback, useContext } from 'react';
 
 import { ConfirmModalContext } from 'context/ConfirmModalContext';
 import { TrelloContext } from 'context/TrelloContext';
@@ -33,7 +33,8 @@ const validateBeforeSave = (cell, board, text) => {
   return true;
 };
 
-const BoardCell = ({ cell, setBoards, board, boardIndex, cellIndex }) => {
+const BoardCell = ({ cell, setBoards, boardIndex, cellIndex }) => {
+  // console.log(cell.name);
   const {
     actions: { openDeleteConfirmModal },
   } = useContext(ConfirmModalContext);
@@ -44,6 +45,9 @@ const BoardCell = ({ cell, setBoards, board, boardIndex, cellIndex }) => {
 
   const [text, setText] = useState(cell.name);
 
+  useEffect(() => {
+    setText(cell.name);
+  }, [cell]);
   const onEnter = useCallback(async () => {
     const { id, trelloType, name, idList, idBoard } = cell;
 
@@ -73,7 +77,7 @@ const BoardCell = ({ cell, setBoards, board, boardIndex, cellIndex }) => {
         responseOfNewCell = await createCard(text, idList);
       }
     }
-
+    // console.log(text);
     setBoards((prevState) => {
       return prevState.map((els) =>
         els.map((el) =>

--- a/src/components/Board/BoardCell/BoardCell.styles.js
+++ b/src/components/Board/BoardCell/BoardCell.styles.js
@@ -28,7 +28,7 @@ export const Container = styled.div`
   word-break: keep-all;
   text-align: center;
 
-  cursor: move;
+  cursor: ${({ isMainBoard }) => (isMainBoard ? 'pointer' : 'move')};
 `;
 
 export const TextArea = styled.textarea.attrs({

--- a/src/components/Board/BoardCell/BoardCell.styles.js
+++ b/src/components/Board/BoardCell/BoardCell.styles.js
@@ -27,6 +27,8 @@ export const Container = styled.div`
   box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 7px;
   word-break: keep-all;
   text-align: center;
+
+  cursor: move;
 `;
 
 export const TextArea = styled.textarea.attrs({

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -5,7 +5,7 @@ const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
   const ref = useRef(null);
 
   const [{ isDragging }, connectDrag] = useDrag({
-    item: { id, type: 'IMG' },
+    item: { id, type: id === 4 ? 'CENTER' : 'CELL' },
     collect: (monitor) => {
       return {
         isDragging: monitor.isDragging(),
@@ -14,7 +14,7 @@ const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
   });
 
   const [, connectDrop] = useDrop({
-    accept: 'IMG',
+    accept: 'CELL',
     hover(hoveredOverItem) {
       if (hoveredOverItem.id !== id) {
         onMoveItem(boardIndex, hoveredOverItem.id, id);

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -4,15 +4,18 @@ import { useDrag, useDrop } from 'react-dnd';
 import { TrelloContext } from 'context/TrelloContext';
 
 const DragItem = memo(
-  ({ id, onMoveItem, onDropItem, boardIndex, children }) => {
+  ({ id, onMoveItem, onDropItem, boardIndex, canDrag, children }) => {
     const {
-      actions: { fetchCardsOnList },
+      actions: { fetchCardsOnList, setCanDrag },
     } = useContext(TrelloContext);
 
     const ref = useRef(null);
 
     const [{ isDragging }, connectDrag] = useDrag({
       item: { id, type: id === 4 ? 'CENTER' : `CELL${boardIndex}` },
+      canDrag() {
+        return canDrag;
+      },
       collect: (monitor) => {
         return {
           isDragging: monitor.isDragging(),
@@ -28,6 +31,7 @@ const DragItem = memo(
         }
       },
       drop() {
+        setCanDrag(false);
         onDropItem(boardIndex, id, fetchCardsOnList);
       },
     });

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -1,0 +1,39 @@
+import React, { memo, useRef } from 'react';
+import { useDrag, useDrop } from 'react-dnd';
+
+const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
+  const ref = useRef(null);
+
+  const [{ isDragging }, connectDrag] = useDrag({
+    item: { id, type: 'IMG' },
+    collect: (monitor) => {
+      return {
+        isDragging: monitor.isDragging(),
+      };
+    },
+  });
+
+  const [, connectDrop] = useDrop({
+    accept: 'IMG',
+    hover(hoveredOverItem) {
+      if (hoveredOverItem.id !== id) {
+        onMoveItem(boardIndex, hoveredOverItem.id, id);
+      }
+    },
+  });
+
+  connectDrag(ref);
+  connectDrop(ref);
+
+  const opacity = isDragging ? 0.5 : 1;
+  const containerStyle = { opacity };
+
+  return React.Children.map(children, (child) =>
+    React.cloneElement(child, {
+      forwardedRef: ref,
+      style: containerStyle,
+    })
+  );
+});
+
+export default DragItem;

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -1,8 +1,14 @@
-import React, { memo, useRef } from 'react';
+import React, { useContext, memo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
+
+import { TrelloContext } from 'context/TrelloContext';
 
 const DragItem = memo(
   ({ id, onMoveItem, onDropItem, boardIndex, children }) => {
+    const {
+      actions: { fetchCardsOnList },
+    } = useContext(TrelloContext);
+
     const ref = useRef(null);
 
     const [{ isDragging }, connectDrag] = useDrag({
@@ -21,11 +27,9 @@ const DragItem = memo(
           onMoveItem(boardIndex, hoveredOverItem.id, id);
         }
       },
-      // drop(dropOverItem) {
-      //   if (dropOverItem.id !== id) {
-      //     onDropItem(boardIndex, dropOverItem.id, id);
-      //   }
-      // },
+      drop() {
+        onDropItem(boardIndex, id, fetchCardsOnList);
+      },
     });
 
     connectDrag(ref);

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -1,39 +1,46 @@
 import React, { memo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
-  const ref = useRef(null);
+const DragItem = memo(
+  ({ id, onMoveItem, onDropItem, boardIndex, children }) => {
+    const ref = useRef(null);
 
-  const [{ isDragging }, connectDrag] = useDrag({
-    item: { id, type: id === 4 ? 'CENTER' : `CELL${boardIndex}` },
-    collect: (monitor) => {
-      return {
-        isDragging: monitor.isDragging(),
-      };
-    },
-  });
+    const [{ isDragging }, connectDrag] = useDrag({
+      item: { id, type: id === 4 ? 'CENTER' : `CELL${boardIndex}` },
+      collect: (monitor) => {
+        return {
+          isDragging: monitor.isDragging(),
+        };
+      },
+    });
 
-  const [, connectDrop] = useDrop({
-    accept: `CELL${boardIndex}`,
-    hover(hoveredOverItem) {
-      if (hoveredOverItem.id !== id) {
-        onMoveItem(boardIndex, hoveredOverItem.id, id);
-      }
-    },
-  });
+    const [, connectDrop] = useDrop({
+      accept: `CELL${boardIndex}`,
+      hover(hoveredOverItem) {
+        if (hoveredOverItem.id !== id) {
+          onMoveItem(boardIndex, hoveredOverItem.id, id);
+        }
+      },
+      // drop(dropOverItem) {
+      //   if (dropOverItem.id !== id) {
+      //     onDropItem(boardIndex, dropOverItem.id, id);
+      //   }
+      // },
+    });
 
-  connectDrag(ref);
-  connectDrop(ref);
+    connectDrag(ref);
+    connectDrop(ref);
 
-  const opacity = isDragging ? 0.5 : 1;
-  const containerStyle = { opacity };
+    const opacity = isDragging ? 0.5 : 1;
+    const containerStyle = { opacity };
 
-  return React.Children.map(children, (child) =>
-    React.cloneElement(child, {
-      forwardedRef: ref,
-      style: containerStyle,
-    })
-  );
-});
+    return React.Children.map(children, (child) =>
+      React.cloneElement(child, {
+        forwardedRef: ref,
+        style: containerStyle,
+      })
+    );
+  }
+);
 
 export default DragItem;

--- a/src/components/DragItem/DragItem.js
+++ b/src/components/DragItem/DragItem.js
@@ -5,7 +5,7 @@ const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
   const ref = useRef(null);
 
   const [{ isDragging }, connectDrag] = useDrag({
-    item: { id, type: id === 4 ? 'CENTER' : 'CELL' },
+    item: { id, type: id === 4 ? 'CENTER' : `CELL${boardIndex}` },
     collect: (monitor) => {
       return {
         isDragging: monitor.isDragging(),
@@ -14,7 +14,7 @@ const DragItem = memo(({ id, onMoveItem, boardIndex, children }) => {
   });
 
   const [, connectDrop] = useDrop({
-    accept: 'CELL',
+    accept: `CELL${boardIndex}`,
     hover(hoveredOverItem) {
       if (hoveredOverItem.id !== id) {
         onMoveItem(boardIndex, hoveredOverItem.id, id);

--- a/src/context/GridContext.js
+++ b/src/context/GridContext.js
@@ -1,0 +1,64 @@
+import React, { useState, createContext } from 'react';
+
+import { replaceArrayOnArray } from 'utils/utils';
+
+const move = (array, oldIndex, newIndex) => {
+  if (newIndex >= array.length) {
+    newIndex = array.length - 1;
+  }
+  array.splice(newIndex, 0, array.splice(oldIndex, 1)[0]);
+
+  return array;
+};
+
+const moveElement = (array, index, offset) => {
+  const newIndex = index + offset;
+  return move(array, index, newIndex);
+};
+
+const Context = createContext();
+
+const { Provider, Consumer: GridConsumer } = Context;
+
+const GridProvider = ({ children }) => {
+  const [dragItems, setDragItems] = useState([[]]);
+  // console.log(dragItems);
+  const moveItem = (boardIndex, sourceId, destinationId) => {
+    const sourceIndex = dragItems[boardIndex].findIndex(
+      (item) => item.id === sourceId
+    );
+    const destinationIndex = dragItems[boardIndex].findIndex(
+      (item) => item.id === destinationId
+    );
+
+    // If source/destination is unknown, do nothing.
+    if (sourceId === -1 || destinationId === -1) {
+      return;
+    }
+
+    const offset = destinationIndex - sourceIndex;
+
+    setDragItems((prevState) =>
+      replaceArrayOnArray(
+        prevState,
+        boardIndex,
+        moveElement(prevState[boardIndex], sourceIndex, offset)
+      )
+    );
+  };
+
+  return (
+    <Provider
+      value={{
+        state: { dragItems },
+        actions: { moveItem, setDragItems },
+      }}
+    >
+      {children}
+    </Provider>
+  );
+};
+
+const GridContext = Context;
+
+export { GridProvider, GridConsumer, GridContext };

--- a/src/context/GridContext.js
+++ b/src/context/GridContext.js
@@ -2,7 +2,6 @@ import React, { useState, createContext } from 'react';
 
 import { updateCard } from 'services/trello';
 import { replaceArrayOnArray } from 'utils/utils';
-import { BOARD_CENTER_INDEX } from 'constants/board';
 
 const move = (array, oldIndex, newIndex) => {
   if (newIndex >= array.length) {
@@ -49,41 +48,22 @@ const GridProvider = ({ children }) => {
     );
   };
 
-  const dropItem = (boardIndex, sourceId, destinationId) => {
-    const sourceIndex = dragItems[boardIndex].findIndex(
-      (item) => item.id === sourceId
-    );
+  const dropItem = async (boardIndex, destinationId, fetchCardsOnList) => {
     const destinationIndex = dragItems[boardIndex].findIndex(
       (item) => item.id === destinationId
     );
+    const items = dragItems[boardIndex]
+      .splice(destinationIndex)
+      .filter((el) => el.name);
 
-    // console.log(sourceIndex, destinationIndex);
-    // If source/destination is unknown, do nothing.
-    if (sourceId === -1 || destinationId === -1) {
-      return;
-    }
-
-    const offset = destinationIndex - sourceIndex;
-    // console.log(sourceIndex, destinationIndex);
-    // console.log(dragItems[boardIndex][sourceIndex]);
-    // console.log(dragItems[boardIndex][destinationIndex]);
-    // TODO 한칸씩은 잘 이동되는데, 한번에 여러 칸 이동이 안됨
-    // updateCard({
-    //   ...dragItems[boardIndex][sourceIndex],
-    //   pos: destinationIndex,
-    // });
-    // updateCard({
-    //   ...dragItems[boardIndex][destinationIndex],
-    //   pos: sourceIndex,
-    // });
-
-    setDragItems((prevState) =>
-      replaceArrayOnArray(
-        prevState,
-        boardIndex,
-        moveElement(prevState[boardIndex], sourceIndex, offset)
-      )
+    const promises = items.map((item, index) =>
+      updateCard({
+        ...item,
+        pos: index + destinationIndex,
+      })
     );
+    await Promise.all(promises);
+    await fetchCardsOnList(items[0].idList, boardIndex);
   };
 
   return (

--- a/src/context/GridContext.js
+++ b/src/context/GridContext.js
@@ -32,13 +32,30 @@ const GridProvider = ({ children }) => {
       (item) => item.id === destinationId
     );
 
-    // center cell은 drag / drop 불가
-    // if (
-    //   sourceIndex === BOARD_CENTER_INDEX ||
-    //   destinationIndex === BOARD_CENTER_INDEX
-    // ) {
-    //   return;
-    // }
+    // console.log(sourceIndex, destinationIndex);
+    // If source/destination is unknown, do nothing.
+    if (sourceId === -1 || destinationId === -1) {
+      return;
+    }
+
+    const offset = destinationIndex - sourceIndex;
+
+    setDragItems((prevState) =>
+      replaceArrayOnArray(
+        prevState,
+        boardIndex,
+        moveElement(prevState[boardIndex], sourceIndex, offset)
+      )
+    );
+  };
+
+  const dropItem = (boardIndex, sourceId, destinationId) => {
+    const sourceIndex = dragItems[boardIndex].findIndex(
+      (item) => item.id === sourceId
+    );
+    const destinationIndex = dragItems[boardIndex].findIndex(
+      (item) => item.id === destinationId
+    );
 
     // console.log(sourceIndex, destinationIndex);
     // If source/destination is unknown, do nothing.
@@ -73,7 +90,7 @@ const GridProvider = ({ children }) => {
     <Provider
       value={{
         state: { dragItems },
-        actions: { moveItem, setDragItems },
+        actions: { moveItem, dropItem, setDragItems },
       }}
     >
       {children}

--- a/src/context/GridContext.js
+++ b/src/context/GridContext.js
@@ -1,13 +1,14 @@
 import React, { useState, createContext } from 'react';
 
+import { updateCard } from 'services/trello';
 import { replaceArrayOnArray } from 'utils/utils';
+import { BOARD_CENTER_INDEX } from 'constants/board';
 
 const move = (array, oldIndex, newIndex) => {
   if (newIndex >= array.length) {
     newIndex = array.length - 1;
   }
   array.splice(newIndex, 0, array.splice(oldIndex, 1)[0]);
-
   return array;
 };
 
@@ -31,12 +32,33 @@ const GridProvider = ({ children }) => {
       (item) => item.id === destinationId
     );
 
+    // center cell은 drag / drop 불가
+    // if (
+    //   sourceIndex === BOARD_CENTER_INDEX ||
+    //   destinationIndex === BOARD_CENTER_INDEX
+    // ) {
+    //   return;
+    // }
+
+    // console.log(sourceIndex, destinationIndex);
     // If source/destination is unknown, do nothing.
     if (sourceId === -1 || destinationId === -1) {
       return;
     }
 
     const offset = destinationIndex - sourceIndex;
+    // console.log(sourceIndex, destinationIndex);
+    // console.log(dragItems[boardIndex][sourceIndex]);
+    // console.log(dragItems[boardIndex][destinationIndex]);
+    // TODO 한칸씩은 잘 이동되는데, 한번에 여러 칸 이동이 안됨
+    // updateCard({
+    //   ...dragItems[boardIndex][sourceIndex],
+    //   pos: destinationIndex,
+    // });
+    // updateCard({
+    //   ...dragItems[boardIndex][destinationIndex],
+    //   pos: sourceIndex,
+    // });
 
     setDragItems((prevState) =>
       replaceArrayOnArray(

--- a/src/context/TrelloContext.js
+++ b/src/context/TrelloContext.js
@@ -110,6 +110,7 @@ const defaultTrelloObjects = {
 
 const TrelloProvider = ({ children }) => {
   const [trelloBoardId, setTrelloBoardId] = useState();
+  const [canDrag, setCanDrag] = useState(false);
   const [boards, setBoards] = useState([[]]);
   const [trelloObjects, setTrelloObjects] = useState({
     ...defaultTrelloObjects,
@@ -136,6 +137,8 @@ const TrelloProvider = ({ children }) => {
             labels,
             isLoaded: true,
           }));
+
+          setCanDrag(true);
         } catch (e) {
           setTrelloObjects({
             ...defaultTrelloObjects,
@@ -148,6 +151,7 @@ const TrelloProvider = ({ children }) => {
   }, [trelloBoardId]);
 
   const fetchCardsOnList = async (_idList, boardIndex) => {
+    if (canDrag) setCanDrag(false);
     const _cards = await getCardsOnList(_idList);
 
     setBoards((prevState) => {
@@ -185,16 +189,19 @@ const TrelloProvider = ({ children }) => {
       ...prevState,
       _cards,
     }));
+    setCanDrag(true);
   };
 
   return (
     <Provider
       value={{
         state: {
+          canDrag,
           boards,
           trelloObjects,
         },
         actions: {
+          setCanDrag,
           setBoards,
           setTrelloBoardId,
           setTrelloObjects,

--- a/src/context/TrelloContext.js
+++ b/src/context/TrelloContext.js
@@ -13,11 +13,12 @@ import { insertItemOnArray, getUUID } from 'utils/utils';
 import { BOARD_CENTER_INDEX, BOARD_LENGTH } from 'constants/board';
 
 const getDummyList = (currentLength, trelloType, defaultProps = {}) =>
-  Array.from({ length: BOARD_LENGTH - 1 - currentLength }, () => ({
+  Array.from({ length: BOARD_LENGTH - 1 - currentLength }, (v, i) => ({
     ...defaultProps,
     id: `${getUUID()}`,
     name: '',
     trelloType,
+    pos: currentLength + i + 1,
   }));
 
 const getCardsByListId = (cards, listId) =>
@@ -40,6 +41,7 @@ const generateBoard = (board, lists, cards) => {
       name: board.name,
       trelloType: TRELLO_COLLECTION_TYPE.BOARDS,
       isCenter: true,
+      pos: BOARD_CENTER_INDEX,
     }
   );
 
@@ -55,17 +57,19 @@ const generateBoard = (board, lists, cards) => {
             ? TRELLO_COLLECTION_TYPE.BOARDS
             : TRELLO_COLLECTION_TYPE.LISTS,
         isCenter: i === BOARD_CENTER_INDEX,
+        pos: i,
       }));
     }
 
     // 각 리스트(보드)에 종속된 카드 (셀) 필터
     const _cards = getCardsByListId(cards, list.id).map(
-      ({ id, name, idBoard, idList }) => ({
+      ({ id, name, idBoard, idList }, _index) => ({
         id,
         name,
         idBoard,
         idList,
         trelloType: TRELLO_COLLECTION_TYPE.CARDS,
+        pos: _index,
       })
     );
 
@@ -85,6 +89,7 @@ const generateBoard = (board, lists, cards) => {
         idBoard: list.idBoard,
         trelloType: TRELLO_COLLECTION_TYPE.LISTS,
         isCenter: true,
+        pos: BOARD_CENTER_INDEX,
       }
     );
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,20 @@
 import React from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import ReactDOM from 'react-dom';
 
+import { GridProvider } from 'context/GridContext';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <DndProvider backend={HTML5Backend}>
+      <GridProvider>
+        <App />
+      </GridProvider>
+    </DndProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,11 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
-  <React.StrictMode>
-    <DndProvider backend={HTML5Backend}>
-      <GridProvider>
-        <App />
-      </GridProvider>
-    </DndProvider>
-  </React.StrictMode>,
+  <DndProvider backend={HTML5Backend}>
+    <GridProvider>
+      <App />
+    </GridProvider>
+  </DndProvider>,
   document.getElementById('root')
 );
 

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -34,23 +34,28 @@ const Dashboard = () => {
 
   return (
     <TrelloConsumer>
-      {({ state: { boards }, actions: { setBoards } }) => (
-        <Container>
-          {isAuthorized && !isLoaded && <Spinner />}
-          {isAuthorized && isLoaded && (
-            <BoardWrapper>
-              {boards.slice(0, BOARD_LENGTH).map((board, index) => (
-                <Board
-                  key={getUUID()}
-                  board={board}
-                  setBoards={setBoards}
-                  boardIndex={index}
-                />
-              ))}
-            </BoardWrapper>
-          )}
-        </Container>
-      )}
+      {({ state: { boards }, actions: { setBoards } }) => {
+        return (
+          <Container>
+            {isAuthorized && !isLoaded && <Spinner />}
+            {isAuthorized && isLoaded && (
+              <BoardWrapper>
+                {boards?.length > 0 &&
+                  boards
+                    .slice(0, BOARD_LENGTH)
+                    .map((board, index) => (
+                      <Board
+                        key={getUUID()}
+                        board={board}
+                        setBoards={setBoards}
+                        boardIndex={index}
+                      />
+                    ))}
+              </BoardWrapper>
+            )}
+          </Container>
+        );
+      }}
     </TrelloConsumer>
   );
 };

--- a/src/services/trello.js
+++ b/src/services/trello.js
@@ -66,11 +66,11 @@ export const createLabel = async (tagName, idBoard) => {
 };
 
 // eslint-disable-next-line no-unused-vars
-export const createCard = async (name, idList) => {
+export const createCard = async (name, idList, pos) => {
   const newCard = {
     idList,
     name,
-    pos: 'bottom',
+    pos,
   };
   return postTrello('cards', newCard);
 };
@@ -78,18 +78,19 @@ export const createCard = async (name, idList) => {
 export const updateCard = async (cell) => {
   if (!cell) return;
 
-  const { id, name } = cell;
+  const { id, name, pos } = cell;
   const card = {
     name,
+    pos,
   };
   return putTrello(`${TRELLO_COLLECTION_TYPE.CARDS}/${id}`, card);
 };
 
-export const createList = async (name, idBoard) => {
+export const createList = async (name, idBoard, pos) => {
   const newList = {
     idBoard,
     name,
-    pos: 'bottom',
+    pos,
   };
   return postTrello('lists', newList);
 };

--- a/src/services/trello.js
+++ b/src/services/trello.js
@@ -44,6 +44,14 @@ export const getCardOnBoardById = (boardId, cardId) => {
 };
 
 /** 
+################ Get from List
+* */
+
+export const getCardsOnList = (listId) => {
+  return getTrello(`lists/${listId}/cards/`);
+};
+
+/** 
 ################ Get collections by id
 * */
 export const getCardById = (cardId) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -21,6 +21,15 @@ export const insertItemOnArray = (arr, index, newItem) => [
   ...arr.slice(index),
 ];
 
+export const replaceArrayOnArray = (arr, index, newArray) => [
+  // part of the array before the specified index
+  ...arr.slice(0, index),
+  // inserted item
+  newArray,
+  // part of the array after the specified index
+  ...arr.slice(index + 1),
+];
+
 export const replaceObejctOnArray = (arr, item) => {
   return arr.map((x) => (item.id === x.id ? item : x));
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,6 +1574,21 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@react-dnd/asap@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-4.0.0.tgz#b300eeed83e9801f51bd66b0337c9a6f04548651"
+  integrity sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==
+
+"@react-dnd/invariant@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-2.0.0.tgz#09d2e81cd39e0e767d7da62df9325860f24e517e"
+  integrity sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==
+
+"@react-dnd/shallowequal@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz#a3031eb54129f2c66b2753f8404266ec7bf67f0a"
+  integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -1872,6 +1887,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -1949,10 +1972,23 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
   integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/react@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -4455,6 +4491,15 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dnd-core@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-11.1.3.tgz#f92099ba7245e49729d2433157031a6267afcc98"
+  integrity sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==
+  dependencies:
+    "@react-dnd/asap" "^4.0.0"
+    "@react-dnd/invariant" "^2.0.0"
+    redux "^4.0.4"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -6070,7 +6115,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9947,6 +9992,23 @@ react-dev-utils@^11.0.1:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
+react-dnd-html5-backend@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-11.1.3.tgz#2749f04f416ec230ea193f5c1fbea2de7dffb8f7"
+  integrity sha512-/1FjNlJbW/ivkUxlxQd7o3trA5DE33QiRZgxent3zKme8DwF4Nbw3OFVhTRFGaYhHFNL1rZt6Rdj1D78BjnNLw==
+  dependencies:
+    dnd-core "^11.1.3"
+
+react-dnd@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.3.tgz#f9844f5699ccc55dfc81462c2c19f726e670c1af"
+  integrity sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==
+  dependencies:
+    "@react-dnd/shallowequal" "^2.0.0"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    dnd-core "^11.1.3"
+    hoist-non-react-statics "^3.3.0"
+
 react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
@@ -10287,6 +10349,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -11640,6 +11710,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
## 작업 내용 (Content)

- 보드 셀의 drag & drop 기능

## 링크 (Links)
- [React-DnD](https://github.com/react-dnd/react-dnd)
- [Chess Example](https://codesandbox.io/s/github/react-dnd/react-dnd/tree/gh-pages/examples_hooks_js/00-chessboard?from-embed=&file=/src/BoardSquare.jsx)
- [react-dnd-grid](https://github.com/tfiechowski/react-dnd-grid-tutorial)

## 기타 사항 (Etc)

- state로 drag item 순서를 갖고있는건 쉽다. 하지만, 이 순서를 트렐로 API로 각각의 card position 값을 업데이트해야해서, API Call이 잦으며 이 업데이트를 통해 반영된 데이터를 또 받아와서 client state업데이트 및  drag state 업데이트를 해야함.
- drag state, trello card state 가 이원화 되어 있는데, 합칠 수 있는 뭔가 더 좋은 방법을 찾으면 좋을 듯.
- 트렐로는 list안에서 card가 중간에 빌 수가 없다. 3x3 board에서는 중간에 cell이 빌 수 있다. 이럴 경우 따로 처리를 안했고, 그냥 trello api 콜하게 되는 순간, 자동으로 순서대로 정렬이 된다. ==> 버그라고 하면 버그이지만, 트렐로 구성과 celll구성의 layout 차이라고 생각하고 따로 처리 하지 않을 생각.
